### PR TITLE
Updated the 'Basic Usage' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ You must handle the output of the page builder data manually. Here is an example
 ```php
 add_filter( 'the_content', function( $content, $id = null ) {
 
-	$id = $id ?: get_the_ID();
+    $id = $id ?: get_the_ID();
 
-	if ( post_type_supports( get_post_type( $id ), 'modular-page-builder' ) ) {
-		$plugin  = MPB_Plugin::get_instance()->get_builder( 'modular-page-builder' );
-		$content = $builder->get_rendered_data( $id );
-	}
+    if ( post_type_supports( get_post_type( $id ), 'modular-page-builder' ) ) {
+        $plugin  = ModularPageBuilder\Plugin::get_instance()->get_builder( 'modular-page-builder' );
+        $content = $plugin->get_rendered_data( $id );
+    }
+    
+    return $content;
 
-	return $content;
-
-}
+});
 ```
 
 ## Custom Modules


### PR DESCRIPTION
The 'Basic Usage' example didn't work for me. It was missing `);` and the MPB_Plugin class didn't exist.
